### PR TITLE
Update item_matches macro to support or (|) syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.9.0
+
+### New features
+
+- `item_matches!` now supports `matches!` like syntax for the patterns,
+  e.g. `item_matches!('a' | 'b')`
+
 ## 0.8.0
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "anpa"
-version = "0.8.0"
+version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anpa"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Andreas Hallberg <habbbe@gmail.com>"]
 description = "A generic monadic parser combinator library inspired by Haskell's parsec."
 keywords = ["parser", "parser-combinator", "parsec"]

--- a/src/lib/json.rs
+++ b/src/lib/json.rs
@@ -20,7 +20,7 @@ fn eat<'a, O>(p: impl StrParser<'a, O>) -> impl StrParser<'a, O> {
 
 fn string_parser<'a, T: From<&'a str>>() -> impl StrParser<'a, T> {
     let unicode = right(skip!('u'), times(4, item_if(|c: char| c.is_ascii_hexdigit())));
-    let escaped = right(item(), or_diff(item_matches!('"', '\\', '/', 'b', 'f', 'n', 'r', 't'),
+    let escaped = right(item(), or_diff(item_matches!('"' | '\\' | '/' | 'b' | 'f' | 'n' | 'r' | 't'),
                                         unicode));
     let parse_until = choose!(find_byte(eq(b'"') | eq(b'\\') | lt(0x20), false);
                                         b'\\' => escaped);

--- a/src/lib/macros.rs
+++ b/src/lib/macros.rs
@@ -167,18 +167,19 @@ macro_rules! right {
     };
 }
 
-/// Variadic parser that succeeds if the next item matches one of the
-/// provided arguments.
+/// Variadic parser that succeeds if the next item matches the provided
+/// patterns. Note that unlike `matches!`, this macro accepts multiple
+/// patterns.
 ///
 /// ### Arguments
-/// * `pattern` - any number of match patterns.
+/// * `patterns` - match patterns (as one would pass to `matches!`)
 ///
 /// ### Example:
 /// ```
 /// use anpa::core::*;
 /// use anpa::item_matches;
 ///
-/// let p = item_matches!('0', '1');
+/// let p = item_matches!('0' | '1');
 ///
 /// assert_eq!(parse(p, "012").result, Some('0'));
 /// assert_eq!(parse(p, "123").result, Some('1'));
@@ -186,8 +187,13 @@ macro_rules! right {
 /// ```
 #[macro_export]
 macro_rules! item_matches {
-    ($($pattern:pat_param $(if $guard:expr)?),+ $(,)?) => {
-        $crate::parsers::item_if(|c| matches!(c, $($pattern $(if $guard)?) |*))
+    ($($($patterns:pat_param)|+ $(if $guard:expr)?),+ $(,)?) => {
+        $crate::parsers::item_if(|c| {
+            match c {
+                $($($patterns)|+ $(if $guard)? => true,)+
+                _ => false
+            }
+        })
     };
 }
 


### PR DESCRIPTION
Bump version to 0.9.0